### PR TITLE
console.py

### DIFF
--- a/console.py
+++ b/console.py
@@ -73,7 +73,7 @@ class HBNBCommand(cmd.Cmd):
                 pline = pline[2].strip()  # pline is now str
                 if pline:
                     # check for *args or **kwargs
-                    if pline[0] is '{' and pline[-1] is'}'\
+                    if pline[0] == '{' and pline[-1] == '}'\
                             and type(eval(pline)) is dict:
                         _args = pline
                     else:
@@ -272,7 +272,7 @@ class HBNBCommand(cmd.Cmd):
                 args.append(v)
         else:  # isolate args
             args = args[2]
-            if args and args[0] is '\"':  # check for quoted arg
+            if args and args[0] == '\"':  # check for quoted arg
                 second_quote = args.find('\"', 1)
                 att_name = args[1:second_quote]
                 args = args[second_quote + 1:]
@@ -280,10 +280,10 @@ class HBNBCommand(cmd.Cmd):
             args = args.partition(' ')
 
             # if att_name was not quoted arg
-            if not att_name and args[0] is not ' ':
+            if not att_name and args[0] != ' ':
                 att_name = args[0]
             # check for quoted val arg
-            if args[2] and args[2][0] is '\"':
+            if args[2] and args[2][0] == '\"':
                 att_val = args[2][1:args[2].find('\"', 1)]
 
             # if att_val was not quoted arg


### PR DESCRIPTION
### Corrections on lines

#### Line 76: [change the is the keyword to ==]
- AirBnB_clone_v2/./console.py:76: SyntaxWarning: "is" with a literal. Did you mean "=="?

#### 76: [change the is the keyword to ==]
- AirBnB_clone_v2/./console.py:76: SyntaxWarning: "is" with a literal. Did you mean "=="?

#### 275: [change the is the keyword to ==]
- AirBnB_clone_v2/./console.py:275: SyntaxWarning: "is" with a literal. Did you mean "=="?

#### 283: [change the is not keyword to ==]
- AirBnB_clone_v2/./console.py:283: SyntaxWarning: "is not" with a literal. Did you mean "!="?

#### 286: [change the is the keyword to ==]
- AirBnB_clone_v2/./console.py:286: SyntaxWarning: "is" with a literal. Did you mean "=="?